### PR TITLE
yellow LED blink using millis()

### DIFF
--- a/StateMachineWithoutTimers/StateMachineWithoutTimers.ino
+++ b/StateMachineWithoutTimers/StateMachineWithoutTimers.ino
@@ -1,6 +1,4 @@
 #include <Arduino.h>
-#include <Arduino_LSM6DS3.h>
-
 
 // Inputs from the app (Switches and buttons on dashboard)
 bool armButton;
@@ -22,7 +20,9 @@ int pirState = 0;
 int eventCount = 0;
 int blinkCount = 0;
 
-unsigned long prevTime = 0;
+
+unsigned long yellowLed_PreviousMillis = 0;
+unsigned long yellowLed_BlinkInterval = 1000;           // interval at which to blink (milliseconds)
 
 
 // transition names
@@ -156,9 +156,24 @@ void EnterState(void) // "enter state" = set the inputs, outputs, and timers for
 // "DoInState" calls the transition when the conditions are met
 void DoInState(void)
 {
+  unsigned long currentMillis = millis();
   switch (state)
   {
   case DISARMED:
+    if (currentMillis - yellowLed_PreviousMillis >= yellowLed_BlinkInterval)
+    {
+      // save the last time you blinked the LED
+      yellowLed_PreviousMillis = currentMillis;
+      if( digitalRead(yellowLed) == HIGH )
+      {
+        digitalWrite(yellowLed, LOW);
+      }
+      else
+      {
+        digitalWrite(yellowLed, HIGH);
+      }
+    }
+
     if (triggerButton == HIGH)
     {
       void TransitionFSM(TransitionEvent_e TRG_BTN);
@@ -240,4 +255,6 @@ void loop()
 { 
   DoInState();
 }
+
+
 


### PR DESCRIPTION
I moved 'State Machine Without Timers' into `/StateMachineWithoutTimers/StateMachineWithoutTimers.ino`  sketch
and added yellow LED blink using `millis()`

This compiles and runs properly for me when I make the following change for it to run on my Nano BLE Sense board

```diff
diff --git a/StateMachineWithoutTimers/StateMachineWithoutTimers.ino b/StateMachineWithoutTimers/StateMachineWithoutTimers.ino
index 06dd3cf..3cf9447 100644
--- a/StateMachineWithoutTimers/StateMachineWithoutTimers.ino
+++ b/StateMachineWithoutTimers/StateMachineWithoutTimers.ino
@@ -10,7 +10,7 @@ bool pir_sensor;

 const int redLed = 2;
 const int greenLed = 3;
-const int yellowLed = 4;
+const int yellowLed = LED_BUILTIN;
 const int blueLed = 5; // Acting as solenoid pin for testing
 const int armedSound = 6;
 const int disarmedSound = 7;
```